### PR TITLE
Optionally close Ulauncher search window after opening a URL

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,12 +21,13 @@ class KeywordQueryEventListener(EventListener):
     def on_event(self, event, extension):
         query = event.get_argument() or str()
 
+        keep_app_open = extension.preferences["stay_open"] == "yes"
         items = [
             ExtensionResultItem(
                 icon = 'images/browser.svg',
                 name = event.get_argument(),
                 description = 'Open %s in a new window of the default browser' % event.get_argument(),
-                on_enter=ExtensionCustomAction(query, keep_app_open=True)
+                on_enter=ExtensionCustomAction(query, keep_app_open=keep_app_open)
             )
         ]
 

--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,13 @@
       "type": "keyword",
       "name": "Default browser",
       "default_value": "l"
+    },
+    {
+      "id": "stay_open",
+      "type": "select",
+      "name": "Keep Ulauncher open after opening a url",
+      "default_value": "no",
+      "options": ["yes", "no"]
     }
   ]
 }


### PR DESCRIPTION
Olá, Kléber. Esta é uma pequena contribuição que achei útil. Gosto que o Ulauncher feche depois de usá-lo para abrir URLs.

Hi Kleber. This is a small change I found useful. I like Ulauncher to close after I use it to open URLs.

This PR adds a preference named "Keep Ulauncher open after opening a url" which controls the value of `ExtensionCustomAction` kwarg `keep_app_open.`

Any interest in merging into your extension?

Thanks in advance!